### PR TITLE
Commit supplier data to the database before indexing

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -105,11 +105,6 @@ def update_supplier_data_impl(supplier, supplier_data, success_code):
 
     try:
         import json
-        supplier_json = json.dumps(supplier.serialize())
-        es_client.index(index=get_supplier_index_name(),
-                        doc_type=SUPPLIER_DOC_TYPE,
-                        body=supplier_json,
-                        id=supplier.code)
         db.session.add(supplier)
         # db.session.add(
         #     AuditEvent(
@@ -119,6 +114,11 @@ def update_supplier_data_impl(supplier, supplier_data, success_code):
         #         data={'update': request_data['suppliers']})
         # )
         db.session.commit()
+        supplier_json = json.dumps(supplier.serialize())
+        es_client.index(index=get_supplier_index_name(),
+                        doc_type=SUPPLIER_DOC_TYPE,
+                        body=supplier_json,
+                        id=supplier.code)
     except TransportError, e:
         return jsonify(message=str(e)), e.status_code
     except IntegrityError as e:


### PR DESCRIPTION
When created for the first time Supplier objects contain attribute
values as they were assigned, so if `supplier.code` is assigned a
string value it's not transformed into integer before the instance
is stored. Which means that document is indexed before database
constraints are checked and values like `"005"` are transformed to
integer `5`. When the same document is updated however, code read
from the database is an integer value, which doesn't match Elasticsearch
`_id = "005"`, so a new document is created when indexing the update.

Moving `db.commit` before Elasticsearch indexing makes sure that the
document in Elasticsearch index matches the value stored in the
database.