### PR TITLE
Fix the test runner so that it enforces PEP8

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 pep8 .
 ./scripts/list_migrations.py
 py.test


### PR DESCRIPTION
Happily, we weren't breaking any PEP8 rules.