### PR TITLE
Patch supplier prices

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -6,7 +6,7 @@ from .. import main
 from ... import db
 from ...models import (
     Supplier, AuditEvent,
-    Service, SupplierFramework, Framework
+    Service, SupplierFramework, Framework, PriceSchedule
 )
 from ...search_indices import es_client, get_supplier_index_name, SUPPLIER_DOC_TYPE, delete_indices, create_indices
 
@@ -140,18 +140,14 @@ def supplier_search():
 
 
 def update_supplier_data_impl(supplier, supplier_data, success_code):
-    supplier.update_from_json(supplier_data)
-
     try:
         import json
+        if 'prices' in supplier_data:
+            db.session.query(PriceSchedule).filter(PriceSchedule.supplier_id == supplier.id).delete()
+
+        supplier.update_from_json(supplier_data)
+
         db.session.add(supplier)
-        # db.session.add(
-        #     AuditEvent(
-        #         audit_type=AuditTypes.supplier_update,
-        #         db_object=supplier,
-        #         user=updater_json['updated_by'],
-        #         data={'update': request_data['suppliers']})
-        # )
         db.session.commit()
         supplier_json = json.dumps(supplier.serialize())
         es_client.index(index=get_supplier_index_name(),

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -9,6 +9,7 @@ from app import db
 from app.models import Address, Supplier, AuditEvent, SupplierFramework, Framework, DraftService, Service
 from ..helpers import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin, isRecentTimestamp
 from random import randint
+from decimal import Decimal
 
 
 class TestGetSupplier(BaseApplicationTest):
@@ -181,6 +182,22 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             ).first()
 
             assert_equal(supplier.name, "New Name")
+
+    def test_price_update(self):
+        response = self.update_request({"prices": [{
+            "serviceRole": {"category": "Business Analysis", "role": "Junior Business Analyst"},
+            "hourlyRate": "1.10",
+            "dailyRate": "2.90"}]})
+        assert_equal(response.status_code, 200)
+
+        with self.app.app_context():
+            supplier = Supplier.query.filter(
+                Supplier.code == 123456
+            ).first()
+
+            price = supplier.prices[0]
+            assert_equal(price.hourly_rate, Decimal('1.10'))
+            assert_equal(price.daily_rate, Decimal('2.90'))
 
     def test_supplier_update_creates_audit_event(self):
         self.update_request({'name': "Name"})


### PR DESCRIPTION
Do not merge - preview

As discussed with Alexey, when patching Supplier we were adding new PriceSchedules rather than updating existing.  This cause duplicate key errors.  Couldn't figure out an elegant way to do this with Alchemy so am now deleting all PriceSchedules when Supplier prices are patched