### PR TITLE
Remove requirement for a brief response to be linked to a service

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -40,9 +40,8 @@ def create_brief_response():
 
     supplier = validate_and_return_supplier(brief_response_json)
 
-    brief_service = get_supplier_service_eligible_for_brief(supplier, brief)
-    if not brief_service:
-        abort(400, "Supplier not eligible")
+    # FIXME: The UK marketplace checks that the supplier has a relevant service and that its day rate meets the budget.
+    # This Australian marketplace should do that too, but Australian suppliers haven't created services yet.
 
     # Check if brief response already exists from this supplier
     if BriefResponse.query.filter(BriefResponse.supplier == supplier, BriefResponse.brief == brief).first():
@@ -54,10 +53,7 @@ def create_brief_response():
         brief=brief,
     )
 
-    brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
-    service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
-
-    brief_response.validate(max_day_rate=service_max_day_rate)
+    brief_response.validate()
 
     db.session.add(brief_response)
     try:

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -204,15 +204,6 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid supplier Code' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_supplier_isnt_eligible(self, live_framework):
-        res = self.create_brief_response({
-            'briefId': self.brief_id,
-            'supplierCode': 1
-        })
-
-        assert res.status_code == 400
-        assert 'Supplier not eligible' in res.get_data(as_text=True)
-
     def test_cannot_respond_to_a_brief_that_isnt_live(self, live_framework):
         with self.app.app_context():
             brief = Brief(
@@ -304,18 +295,6 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 201, data
-
-    @given(example_listings.specialists_brief_response_data(min_day_rate=1001, max_day_rate=100000))
-    def test_day_rate_should_be_less_than_service_max_price(self, live_framework, brief_response_data):
-        res = self.create_brief_response(dict(brief_response_data, **{
-            'briefId': self.specialist_brief_id,
-            'supplierCode': 0,
-        }))
-
-        data = json.loads(res.get_data(as_text=True))
-
-        assert res.status_code == 400, data
-        assert data == {'error': {'dayRate': 'max_less_than_min'}}
 
 
 class TestGetBriefResponse(BaseBriefResponseTest):


### PR DESCRIPTION
This is reasonable logic, but no Australian suppliers have services
right now.  The checks can be put back in when they do.