### PR TITLE
Add some missing cascades

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -657,7 +657,7 @@ class User(db.Model):
 
     # FIXME: should be a many-to-many
     supplier_code = db.Column(db.BigInteger,
-                              db.ForeignKey('supplier.code'),
+                              db.ForeignKey('supplier.code', ondelete='cascade'),
                               index=True, unique=False, nullable=True)
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=False)
@@ -749,7 +749,8 @@ class SupplierUserInviteLog(db.Model):
     __table_args__ = (
         db.ForeignKeyConstraint(
             ('supplier_id', 'contact_id'),
-            ('supplier__contact.supplier_id', 'supplier__contact.contact_id')
+            ('supplier__contact.supplier_id', 'supplier__contact.contact_id'),
+            ondelete='cascade',
         ),
     )
 

--- a/migrations/versions/780_add_missing_cascades.py
+++ b/migrations/versions/780_add_missing_cascades.py
@@ -1,0 +1,56 @@
+"""Add missing cascades
+
+Revision ID: 780
+Revises: 770
+Create Date: 2016-09-26 09:50:51.052115
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '780'
+down_revision = '770'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_constraint('supplier_user_invite_log_supplier_id_fkey1', 'supplier_user_invite_log', type_='foreignkey')
+    op.create_foreign_key(
+        'supplier_user_invite_log_supplier_id_fkey1',
+        'supplier_user_invite_log',
+        'supplier__contact',
+        ('supplier_id', 'contact_id'),
+        ('supplier_id', 'contact_id'),
+        ondelete='cascade',
+    )
+
+    op.drop_constraint('user_supplier_code_fkey', 'user', type_='foreignkey')
+    op.create_foreign_key(
+        'user_supplier_code_fkey',
+        'user',
+        'supplier',
+        ('supplier_code',),
+        ('code',),
+        ondelete='cascade',
+    )
+
+
+def downgrade():
+    op.drop_constraint('supplier_user_invite_log_supplier_id_fkey1', 'supplier_user_invite_log', type_='foreignkey')
+    op.create_foreign_key(
+        'supplier_user_invite_log_supplier_id_fkey1',
+        'supplier_user_invite_log',
+        'supplier__contact',
+        ('supplier_id', 'contact_id'),
+        ('supplier_id', 'contact_id'),
+    )
+
+    op.drop_constraint('user_supplier_code_fkey', 'user', type_='foreignkey')
+    op.create_foreign_key(
+        'user_supplier_code_fkey',
+        'user',
+        'supplier',
+        ('supplier_code',),
+        ('code',),
+    )


### PR DESCRIPTION
These allow us to delete Supplier instances cleanly, even if they have
foreign key relations to associated data.