### PR TITLE
Fix dashboard numbers

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -178,6 +178,8 @@ def get_briefs_stats():
     all_briefs = brief_query.order_by(desc(Brief.published_at)).all()
 
     briefs = {
+        'total': brief_query.count(),
+
         'open_to_all': brief_query.filter(Brief.data['sellerSelector'].astext == 'allSellers').count(),
 
         'open_to_selected': brief_query.filter(Brief.data['sellerSelector'].astext == 'someSellers').count(),

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -132,7 +132,7 @@ def delete_suppliers():
 @main.route('/suppliers/count', methods=['GET'])
 def get_suppliers_stats():
     suppliers = {
-        "total": Supplier.query.count()
+        "total": Supplier.query.filter(Supplier.abn != Supplier.DUMMY_ABN).count()
     }
 
     return jsonify(suppliers=suppliers)


### PR DESCRIPTION
Two problems resolved here:
- Briefs were being split (and recombined in the frontend) based on who they are open to. This is not required and could omit some that were made before this data was added. 
- Supplier count was including Dummy/Example suppliers that don't appear in search. In staging, there are 4 of these suppliers explaining the discrepancy.