### PR TITLE
Copy logic to create application from supplier

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -557,7 +557,6 @@ def create_application_from_supplier(code):
 
     for user in users:
         user.application_id = application.id
-        db.session.add(user)
 
     db.session.commit()
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,10 +2,12 @@ from datetime import datetime
 
 from flask import abort, current_app, jsonify, request, url_for
 from sqlalchemy.exc import IntegrityError, DataError
+from sqlalchemy.sql.expression import true
 from .. import main
 from ... import db
 from ...models import (
-    Supplier, AuditEvent, SupplierFramework, Framework, PriceSchedule, User, Domain, ServiceRole, SupplierDomain
+    Supplier, AuditEvent, SupplierFramework, Framework, PriceSchedule, User, Domain, Application,
+    ServiceRole, SupplierDomain
 )
 
 from sqlalchemy.sql import func, desc, or_, asc
@@ -18,6 +20,8 @@ from app.utils import (
 )
 from ...supplier_utils import validate_agreement_details_data
 from dmapiclient.audit import AuditTypes
+from dmutils.logging import notify_team
+import json
 
 
 @main.route('/suppliers', methods=['GET'])
@@ -505,6 +509,59 @@ def update_supplier_framework_details(code, framework_slug):
 def get_domains_list():
     result = [d.serializable for d in Domain.query.order_by('ordering').all()]
     return jsonify(domains=result)
+
+
+@main.route('/suppliers/<int:code>/create-application', methods=['POST'])
+def create_application_from_supplier(code):
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ["current_user"])
+    current_user = json_payload["current_user"]
+
+    supplier = Supplier.query.filter(
+        Supplier.code == code
+    ).first_or_404()
+
+    if 'application_id' in supplier.data:
+        return abort(400, 'Supplier already has application')
+
+    data = json.loads(supplier.json)
+
+    data['status'] = 'saved'
+    data = {key: data[key] for key in data if key not in ['id', 'contacts', 'domains', 'prices']}
+
+    application = Application()
+    application.update_from_json(data)
+
+    db.session.add(application)
+    db.session.add(AuditEvent(
+        audit_type=AuditTypes.create_application,
+        user='',
+        data={},
+        db_object=application
+    ))
+
+    db.session.flush()
+
+    notification_message = '{}\nApplication Id:{}\nBy: {} ({})'.format(
+        data['name'],
+        application.id,
+        current_user['name'],
+        current_user['email_address']
+    )
+    notify_team('An existing seller has started a new application', notification_message)
+
+    supplier.update_from_json({'application_id': application.id})
+    users = User.query.filter(
+        User.supplier_code == code and User.active == true()
+    ).all()
+
+    for user in users:
+        user.application_id = application.id
+        db.session.add(user)
+
+    db.session.commit()
+
+    return jsonify(application=application)
 
 
 @main.route('/suppliers/<int:supplier_id>/domains/<int:domain_id>/<string:status>', methods=['POST'])

--- a/app/models.py
+++ b/app/models.py
@@ -661,6 +661,12 @@ class Supplier(db.Model):
             d: True for d in self.assessed_domains
         }
 
+        if self.contacts:
+            contact = self.contacts[0]
+            j['representative'] = contact.name
+            j['email'] = contact.email
+            j['phone'] = contact.phone
+
         return j
 
     def update_from_json_before(self, data):

--- a/config.py
+++ b/config.py
@@ -61,6 +61,7 @@ class Config:
     JUST_IN_TIME_ASSESSMENTS = False
 
     ROLLBAR_TOKEN = None
+    DM_TEAM_SLACK_WEBHOOK = None
 
     LEGACY_ROLE_MAPPING = True
 

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -1,11 +1,9 @@
 import json
 import mock
-import time
 
-from tests.app.helpers import BaseApplicationTest, INCOMING_APPLICATION_DATA
+from tests.app.helpers import BaseApplicationTest
 
-from app.models import db, Application, AuditEvent, User, utcnow, Agreement
-from dmapiclient.audit import AuditTypes
+from app.models import db, AuditEvent, User, utcnow, Agreement
 
 
 class BaseApplicationsTest(BaseApplicationTest):
@@ -16,23 +14,6 @@ class BaseApplicationsTest(BaseApplicationTest):
             self.setup_dummy_user(id=0, role="applicant")
             self.setup_dummy_user(id=1, role="applicant")
             db.session.commit()
-
-    @mock.patch('app.models.get_marketplace_jira')
-    def setup_dummy_application(self, mj, data=None):
-        if data is None:
-            data = self.application_data
-        with self.app.app_context():
-            application = Application(
-                data=data,
-            )
-
-            db.session.add(application)
-            db.session.flush()
-
-            application.submit_for_approval()
-            db.session.commit()
-
-            return application.id
 
     def setup_dummy_applicant(self, id, application_id):
         with self.app.app_context():
@@ -110,10 +91,6 @@ class BaseApplicationsTest(BaseApplicationTest):
     def get_user(self, user_id):
         user = self.client.get('/users/{}'.format(user_id))
         return json.loads(user.get_data(as_text=True))['users']
-
-    @property
-    def application_data(self):
-        return INCOMING_APPLICATION_DATA
 
 
 class TestCreateApplication(BaseApplicationsTest):


### PR DESCRIPTION
Logic that exists in supplier frontend that occasionally casues 2 applications to be created.

All db updates now occur in single transaction.  Will need to refactor supplier frontend once this is live. 