### PR TITLE
Allow suppliers with a response draft to still access brief attachments

### DIFF
--- a/app/api/views/briefs.py
+++ b/app/api/views/briefs.py
@@ -1117,7 +1117,7 @@ def download_brief_attachment(brief_id, slug):
         (
             current_user.role == 'buyer' or (
                 current_user.role == 'supplier' and
-                _can_do_brief_response(brief_id)
+                _can_do_brief_response(brief_id, update_only=True)
             )
         )
     ):


### PR DESCRIPTION
The `_can_do_brief_response()` check when requesting a brief's attachment was failing as it wasn't in "update_only" mode, which doesn't fail when a response is already created.