### PR TITLE
Clean labour hire data for new and existing seller applications

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2968,18 +2968,15 @@ class Application(db.Model):
             else:
                 supplier = Supplier()
 
-            if self.data.get('recruiter') == 'no':
-                self.data['labourHire'] = {}
-            else:
-                to_remove = []
-                for state, state_value in self.data.get('labourHire', {}).iteritems():
-                    if not (
-                        state_value.get('expiry') and
-                        state_value.get('licenceNumber')
-                    ):
-                        to_remove.append(state)
-                for r in to_remove:
-                    self.data.get('labourHire', {}).pop(r)
+            to_remove = []
+            for state, state_value in self.data.get('labourHire', {}).iteritems():
+                if not (
+                    state_value.get('expiry') and
+                    state_value.get('licenceNumber')
+                ):
+                    to_remove.append(state)
+            for r in to_remove:
+                self.data.get('labourHire', {}).pop(r)
 
             supplier.update_from_json(self.data)
 

--- a/app/models.py
+++ b/app/models.py
@@ -2965,22 +2965,22 @@ class Application(db.Model):
                 self.data.pop('representative', None)
                 self.data.pop('phone', None)
                 self.data.pop('email', None)
-
-                if self.data.get('recruiter') == 'no':
-                    self.data['labourHire'] = {}
-                else:
-                    to_remove = []
-                    for state, state_value in self.data.get('labourHire', {}).iteritems():
-                        if not (
-                            state_value.get('expiry') and
-                            state_value.get('licenceNumber')
-                        ):
-                            to_remove.append(state)
-                    for r in to_remove:
-                        self.data.get('labourHire', {}).pop(r)
-
             else:
                 supplier = Supplier()
+
+            if self.data.get('recruiter') == 'no':
+                self.data['labourHire'] = {}
+            else:
+                to_remove = []
+                for state, state_value in self.data.get('labourHire', {}).iteritems():
+                    if not (
+                        state_value.get('expiry') and
+                        state_value.get('licenceNumber')
+                    ):
+                        to_remove.append(state)
+                for r in to_remove:
+                    self.data.get('labourHire', {}).pop(r)
+
             supplier.update_from_json(self.data)
 
             if not existing:

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1188,7 +1188,6 @@ class TestApplication(BaseApplicationTest):
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
-            'recruiter': 'no',
             'labourHire': {
                 'qld': {'expiry': ''},
                 'sa': {'expiry': '', 'licenceNumber': ''},
@@ -1196,39 +1195,6 @@ class TestApplication(BaseApplicationTest):
             }
         },
         {
-            'recruiter': 'no',
-            'labourHire': {
-                'qld': {'expiry': None},
-                'sa': {'expiry': None, 'licenceNumber': None},
-                'vic': {'licenceNumber': None}
-            }
-        },
-        {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '', 'licenceNumber': ''},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': None},
-                'sa': {'expiry': None, 'licenceNumber': None},
-                'vic': {'licenceNumber': None}
-            }
-        },
-        {
-            'recruiter': 'both',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '', 'licenceNumber': ''},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'both',
             'labourHire': {
                 'qld': {'expiry': None},
                 'sa': {'expiry': None, 'licenceNumber': None},
@@ -1239,7 +1205,6 @@ class TestApplication(BaseApplicationTest):
     def test_labour_hire_data_is_removed_for_new_seller_application(self, jira, app, new_application,
                                                                     applicant, test_data):
         with app.app_context():
-            new_application.data['recruiter'] = test_data['recruiter']
             new_application.data['labourHire'] = test_data['labourHire']
 
             assert new_application.status == 'saved'
@@ -1258,7 +1223,6 @@ class TestApplication(BaseApplicationTest):
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
-            'recruiter': 'no',
             'labourHire': {
                 'qld': {'expiry': ''},
                 'sa': {'expiry': '', 'licenceNumber': ''},
@@ -1266,39 +1230,6 @@ class TestApplication(BaseApplicationTest):
             }
         },
         {
-            'recruiter': 'no',
-            'labourHire': {
-                'qld': {'expiry': None},
-                'sa': {'expiry': None, 'licenceNumber': None},
-                'vic': {'licenceNumber': None}
-            }
-        },
-        {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '', 'licenceNumber': ''},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': None},
-                'sa': {'expiry': None, 'licenceNumber': None},
-                'vic': {'licenceNumber': None}
-            }
-        },
-        {
-            'recruiter': 'both',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '', 'licenceNumber': ''},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'both',
             'labourHire': {
                 'qld': {'expiry': None},
                 'sa': {'expiry': None, 'licenceNumber': None},
@@ -1309,7 +1240,6 @@ class TestApplication(BaseApplicationTest):
     def test_labour_hire_data_is_removed_for_existing_seller_application(self, jira, app, existing_application,
                                                                          supplier_user, test_data):
         with app.app_context():
-            existing_application.data['recruiter'] = test_data['recruiter']
             existing_application.data['labourHire'] = test_data['labourHire']
 
             assert existing_application.status == 'saved'
@@ -1328,15 +1258,6 @@ class TestApplication(BaseApplicationTest):
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'both',
             'labourHire': {
                 'qld': {'expiry': ''},
                 'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
@@ -1347,7 +1268,6 @@ class TestApplication(BaseApplicationTest):
     def test_labour_hire_data_is_retained_for_new_seller_application(self, jira, app, new_application,
                                                                      applicant, test_data):
         with app.app_context():
-            new_application.data['recruiter'] = test_data['recruiter']
             new_application.data['labourHire'] = test_data['labourHire']
 
             assert new_application.status == 'saved'
@@ -1373,15 +1293,6 @@ class TestApplication(BaseApplicationTest):
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
-            'recruiter': 'yes',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
-                'vic': {'licenceNumber': ''}
-            }
-        },
-        {
-            'recruiter': 'both',
             'labourHire': {
                 'qld': {'expiry': ''},
                 'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
@@ -1392,7 +1303,6 @@ class TestApplication(BaseApplicationTest):
     def test_labour_hire_data_is_retained_for_existing_seller_application(self, jira, app, existing_application,
                                                                           supplier_user, test_data):
         with app.app_context():
-            existing_application.data['recruiter'] = test_data['recruiter']
             existing_application.data['labourHire'] = test_data['labourHire']
 
             assert existing_application.status == 'saved'
@@ -1414,67 +1324,6 @@ class TestApplication(BaseApplicationTest):
             supplier = existing_application.supplier
             supplier_labour_hire = supplier.data.get('labourHire')
             assert supplier_labour_hire == expected
-
-    @mock.patch('app.jiraapi.JIRA')
-    @pytest.mark.parametrize('test_data', [
-        {
-            'recruiter': 'no',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
-                'vic': {'licenceNumber': ''}
-            }
-        }
-    ])
-    def test_labour_hire_data_is_removed_for_non_recruiter_new_seller_application(self, jira, app, new_application,
-                                                                                  applicant, test_data):
-        with app.app_context():
-            new_application.data['recruiter'] = test_data['recruiter']
-            new_application.data['labourHire'] = test_data['labourHire']
-
-            assert new_application.status == 'saved'
-            new_application.submit_for_approval()
-            assert new_application.status == 'submitted'
-            new_application.set_approval(approved=True)
-            assert new_application.status == 'approved'
-
-            labour_hire = new_application.data.get('labourHire')
-            assert labour_hire == {}
-
-            supplier = new_application.supplier
-            supplier_labour_hire = supplier.data.get('labourHire')
-            assert supplier_labour_hire == {}
-
-    @mock.patch('app.jiraapi.JIRA')
-    @pytest.mark.parametrize('test_data', [
-        {
-            'recruiter': 'no',
-            'labourHire': {
-                'qld': {'expiry': ''},
-                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
-                'vic': {'licenceNumber': ''}
-            }
-        }
-    ])
-    def test_labour_hire_data_is_removed_for_non_recruiter_existing_seller_application(self, jira, app,
-                                                                                       existing_application,
-                                                                                       supplier_user, test_data):
-        with app.app_context():
-            existing_application.data['recruiter'] = test_data['recruiter']
-            existing_application.data['labourHire'] = test_data['labourHire']
-
-            assert existing_application.status == 'saved'
-            existing_application.submit_for_approval()
-            assert existing_application.status == 'submitted'
-            existing_application.set_approval(approved=True)
-            assert existing_application.status == 'approved'
-
-            labour_hire = existing_application.data.get('labourHire')
-            assert labour_hire == {}
-
-            supplier = existing_application.supplier
-            supplier_labour_hire = supplier.data.get('labourHire')
-            assert supplier_labour_hire == {}
 
     @mock.patch('app.jiraapi.JIRA')
     def test_new_seller_application(self, jira, app):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1312,6 +1312,46 @@ class TestApplication(BaseApplicationTest):
             assert labour_hire == {}
 
     @mock.patch('app.jiraapi.JIRA')
+    @pytest.mark.parametrize('test_data', [
+        {
+            'recruiter': 'yes',
+            'labourHire': {
+                'qld': {'expiry': ''},
+                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
+                'vic': {'licenceNumber': ''}
+            }
+        },
+        {
+            'recruiter': 'both',
+            'labourHire': {
+                'qld': {'expiry': ''},
+                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
+                'vic': {'licenceNumber': ''}
+            }
+        }
+    ])
+    def test_labour_hire_data_is_retained_for_new_seller_application(self, jira, app, new_application,
+                                                                     applicant, test_data):
+        with app.app_context():
+            new_application.data['recruiter'] = test_data['recruiter']
+            new_application.data['labourHire'] = test_data['labourHire']
+
+            assert new_application.status == 'saved'
+            new_application.submit_for_approval()
+            assert new_application.status == 'submitted'
+            new_application.set_approval(approved=True)
+            assert new_application.status == 'approved'
+
+            labour_hire = new_application.data.get('labourHire')
+            assert labour_hire == {
+                'sa': {
+                    'expiry': '2040-10-22',
+                    'licenceNumber': '123'
+                }
+            }
+
+
+    @mock.patch('app.jiraapi.JIRA')
     def test_new_seller_application(self, jira, app):
         with app.test_request_context('/hello'):
             application = Application(data=INCOMING_APPLICATION_DATA)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1245,6 +1245,10 @@ class TestApplication(BaseApplicationTest):
             labour_hire = new_application.data.get('labourHire')
             assert labour_hire == {}
 
+            supplier = new_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == {}
+
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
@@ -1311,6 +1315,10 @@ class TestApplication(BaseApplicationTest):
             labour_hire = existing_application.data.get('labourHire')
             assert labour_hire == {}
 
+            supplier = existing_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == {}
+
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
@@ -1342,13 +1350,19 @@ class TestApplication(BaseApplicationTest):
             new_application.set_approval(approved=True)
             assert new_application.status == 'approved'
 
-            labour_hire = new_application.data.get('labourHire')
-            assert labour_hire == {
+            expected = {
                 'sa': {
                     'expiry': '2040-10-22',
                     'licenceNumber': '123'
                 }
             }
+
+            labour_hire = new_application.data.get('labourHire')
+            assert labour_hire == expected
+
+            supplier = new_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == expected
 
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
@@ -1381,13 +1395,19 @@ class TestApplication(BaseApplicationTest):
             existing_application.set_approval(approved=True)
             assert existing_application.status == 'approved'
 
-            labour_hire = existing_application.data.get('labourHire')
-            assert labour_hire == {
+            expected = {
                 'sa': {
                     'expiry': '2040-10-22',
                     'licenceNumber': '123'
                 }
             }
+
+            labour_hire = existing_application.data.get('labourHire')
+            assert labour_hire == expected
+
+            supplier = existing_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == expected
 
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
@@ -1415,6 +1435,10 @@ class TestApplication(BaseApplicationTest):
             labour_hire = new_application.data.get('labourHire')
             assert labour_hire == {}
 
+            supplier = new_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == {}
+
     @mock.patch('app.jiraapi.JIRA')
     @pytest.mark.parametrize('test_data', [
         {
@@ -1441,6 +1465,10 @@ class TestApplication(BaseApplicationTest):
 
             labour_hire = existing_application.data.get('labourHire')
             assert labour_hire == {}
+
+            supplier = existing_application.supplier
+            supplier_labour_hire = supplier.data.get('labourHire')
+            assert supplier_labour_hire == {}
 
     @mock.patch('app.jiraapi.JIRA')
     def test_new_seller_application(self, jira, app):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1119,7 +1119,13 @@ class TestApplication(BaseApplicationTest):
         with app.app_context():
             self.setup_dummy_suppliers(1)
             db.session.commit()
-            supplier = Supplier.query.filter(Supplier.code == 0).first()
+            supplier = (
+                db.session
+                  .query(Supplier)
+                  .filter(Supplier.code == 0)
+                  .first()
+            )
+
             yield supplier
 
     @pytest.fixture()

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1416,6 +1416,33 @@ class TestApplication(BaseApplicationTest):
             assert labour_hire == {}
 
     @mock.patch('app.jiraapi.JIRA')
+    @pytest.mark.parametrize('test_data', [
+        {
+            'recruiter': 'no',
+            'labourHire': {
+                'qld': {'expiry': ''},
+                'sa': {'expiry': '2040-10-22', 'licenceNumber': '123'},
+                'vic': {'licenceNumber': ''}
+            }
+        }
+    ])
+    def test_labour_hire_data_is_removed_for_non_recruiter_existing_seller_application(self, jira, app,
+                                                                                       existing_application,
+                                                                                       supplier_user, test_data):
+        with app.app_context():
+            existing_application.data['recruiter'] = test_data['recruiter']
+            existing_application.data['labourHire'] = test_data['labourHire']
+
+            assert existing_application.status == 'saved'
+            existing_application.submit_for_approval()
+            assert existing_application.status == 'submitted'
+            existing_application.set_approval(approved=True)
+            assert existing_application.status == 'approved'
+
+            labour_hire = existing_application.data.get('labourHire')
+            assert labour_hire == {}
+
+    @mock.patch('app.jiraapi.JIRA')
     def test_new_seller_application(self, jira, app):
         with app.test_request_context('/hello'):
             application = Application(data=INCOMING_APPLICATION_DATA)


### PR DESCRIPTION
This pull request fixes (hopefully 🤞 ) an issue where incomplete labour hire data is being saved when an application is approved.  This was originally preventing users from downloading reports (see #760 ).  It looks like the logic to clean the `labourHire` dictionary wasn't being done for new seller applications.

In the process of adding tests, I had to update some existing ones.

Addresses MAR-4138