### PR TITLE
Bump boto package versions to match what utils is using

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ bcrypt==3.1.3
 billiard==3.5.0.3
 bleach==3.1.0
 blinker==1.4
-boto==2.46.1
-boto3==1.7.47
-botocore==1.10.47
+boto==2.49.0
+boto3==1.9.19
+botocore==1.12.19
 celery==4.2.1
 cffi==1.10.0
 click==6.7


### PR DESCRIPTION
I ran into a problem where I couldn't upload files locally when testing the application flow. I discovered that the utils repository was running later versions of the boto packages. This pull request updates the boto packages to make them consistent with what utils is running.