### PR TITLE
Use disk instead of memory when creating responses zip

### DIFF
--- a/manifest.celery.production.yml
+++ b/manifest.celery.production.yml
@@ -3,7 +3,7 @@ buildpack: python2_buildpack
 health-check-type: process
 instances: 1
 memory: 2G
-disk_quota: 512M
+disk_quota: 1G
 services:
 - pgdb-96-prod
 - ups-dm-common


### PR DESCRIPTION
The Celery task that creates a zip file for buyers to download seller responses has failed in the past due to memory problems.  When the task encounters an opportunity with many responses it triggers a: `WorkerLostError: Worker exited prematurely: signal 9 (SIGKILL)` (eg. the size of the documents for opportunity 8109 is approximately 477 MB).

#754 solved this by increasing the memory that the Celery app uses but we're continuing to see this error for opportunities with many responses.  This pull request replaces BytesIO with tempfile and increases the disk quota of the Celery app.

Addresses MAR-4288