### PR TITLE
Bump Mailchimp package to remove logging of raw responses

### DIFF
--- a/app/tasks/mailchimp.py
+++ b/app/tasks/mailchimp.py
@@ -152,11 +152,6 @@ def add_members_to_list(client, list_id, email_addresses):
         }
 
         response = client.lists.update_members(list_id=list_id, data=data)
-
-        current_app.logger.info(
-            '{} were added to Mailchimp list {}'.format(', '.join(email_addresses), list_id)
-        )
-
         return response
     except RequestException as e:
         # publish error in slack and rollbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ jira==1.0.10
 jmespath==0.9.2
 jsonschema==2.6.0
 kombu==4.2.1
-mailchimp3==3.0.6
+mailchimp3==3.0.10
 Mako==1.0.7
 Markdown==2.6.8
 MarkupSafe==1.0


### PR DESCRIPTION
Based on the [commit history](https://github.com/VingtCinq/python-mailchimp/commits/master) of the mailchimp3 project, it looks like there have been minimal changes between 3.0.6 and [3.0.10](https://github.com/VingtCinq/python-mailchimp/commit/9804811be098d4846ff050fcde4439d6c1431ea0).  This is the release that stops logging raw responses.